### PR TITLE
fixing deprecation warning

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -109,7 +109,7 @@ class remi (
 
     remi::rpm_gpg_key{ 'remi':
       path   => '/etc/pki/rpm-gpg/RPM-GPG-KEY-remi',
-      before => yumrepo['remi','remi-php55','remi-php56','remi-php70','remi-test','remi-debuginfo', 'remi-test-debuginfo'],
+      before => Yumrepo['remi','remi-php55','remi-php56','remi-php70','remi-test','remi-debuginfo', 'remi-test-debuginfo'],
     }
   } else {
       notice ("Your operating system ${::operatingsystem} will not have the REMI repository applied")


### PR DESCRIPTION
Warning: Deprecation notice:  Resource references should now be capitalized on line 112 in file /tmp/vagrant-puppet/modules-5d8b4bf1914aa0f451d55d87470ac77a/remi/manifests/init.pp

this changes fixes the puppet 3.7.4 deprecation warning