### PR TITLE
Fix dependency for parsing with librarian-puppet

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -41,6 +41,6 @@
   ],
   "description": "Setup the REMI package repo on Centos/RHEL et al",
   "dependencies": [
-    {"name":"stahnma/epel","version_requirement":">= 1.0.2  <2.0.0"}
+    {"name":"stahnma/epel","version_requirement":">= 1.0.2 < 2.0.0"}
   ]
 }


### PR DESCRIPTION
Hi, 
While adding your module as a dependency in librarian-puppet, the dependency cannot be read correctly. 

The following error is received: 

```
[Librarian]   Module m0byd1ck-remi found versions: 1.0.3, 1.0.2, 1.0.1, 1.0.0, 0.0.2, 0.0.1
[Librarian]     Checking m0byd1ck-remi/1.0.3 <https://forgeapi.puppetlabs.com>
/usr/lib/ruby/2.2.0/rubygems/requirement.rb:89:in `parse': Illformed requirement [">= 1.0.2  <2.0.0"] (Gem::Requirement::BadRequirementError)
```

Adding a whitespace makes librarian-puppet happy again; thanks!
